### PR TITLE
Create indicator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,115 @@
+### macOS ###
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+# Thumbnails
+._*
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+.venv/
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject

--- a/nbtimetravel/__init__.py
+++ b/nbtimetravel/__init__.py
@@ -1,7 +1,7 @@
 def _jupyter_nbextension_paths():
     return [{
         "section": "notebook",
-        "dest": "noteboard-nbextension",
+        "dest": "nbtimetravel",
         "src": "static",
-        "require": "noteboard-nbextension/main"
+        "require": "nbtimetravel/main"
     }]

--- a/nbtimetravel/static/main.js
+++ b/nbtimetravel/static/main.js
@@ -1,56 +1,56 @@
 define([
-    'base/js/namespace',
-    'notebook/js/outputarea',
-    'base/js/events',
+  'base/js/namespace',
+  'notebook/js/outputarea',
+  'base/js/events',
 ], function (
-    Jupyter, oa, events
+  Jupyter, oa, events
 ) {
-    // No event for this, so we monkeypatch!
-    // MONKEY SEE, MONKEY PATCH!
-    oa.OutputArea.prototype._handle_output = oa.OutputArea.prototype.handle_output;
-    oa.OutputArea.prototype.handle_output = function (msg) {
-        if (!this.cell.metadata.history) {
-            this.cell.metadata.history = [];
-        }
-        this.cell.metadata.history.push({
-            // Record dates clientside, rather than serverside.
-            // This lets us consistently use the same time source in *most*
-            // cases.
-            timestamp: (new Date()).toISOString(),
-            code: this.cell.get_text(),
-            // We record the responses that're required to recreate the state
-            // in the OutputArea object.
-            response: {
-                version: msg.header.version,
-                msg_type: msg.msg_type,
-                content: msg.content,
-                metadata: msg.metadata
-            }
-        });
+  // No event for this, so we monkeypatch!
+  // MONKEY SEE, MONKEY PATCH!
+  oa.OutputArea.prototype._handle_output = oa.OutputArea.prototype.handle_output;
+  oa.OutputArea.prototype.handle_output = function (msg) {
+    if (!this.cell.metadata.history) {
+      this.cell.metadata.history = [];
+    }
+    this.cell.metadata.history.push({
+      // Record dates clientside, rather than serverside.
+      // This lets us consistently use the same time source in *most*
+      // cases.
+      timestamp: (new Date()).toISOString(),
+      code: this.cell.get_text(),
+      // We record the responses that're required to recreate the state
+      // in the OutputArea object.
+      response: {
+        version: msg.header.version,
+        msg_type: msg.msg_type,
+        content: msg.content,
+        metadata: msg.metadata
+      }
+    });
 
-        return this._handle_output(msg);
+    return this._handle_output(msg);
+  };
+
+  var load_ipython_extension = function () {
+    events.on('execute.CodeCell', function(ev, payload){
+      // Output area objects don't know what cells they belong to!
+      // We use this to tell them
+      // We keep re-setting it, but the other option was to monkeypatch
+      // CodeCell's fromJSON (for initial cell loading) and create_element
+      // calls. Unfortunately nbextensions run too late to usefully
+      // monkeypatch fromJSON, so this is what we gotta do.
+      payload.cell.output_area.cell = payload.cell;
+    });
+
+    // Add some metadata to the notebook itself
+    // This allows us to incrementally upgrade our format in the future
+    // in backwards compatible ways
+    Jupyter.notebook.metadata.timetravel = {
+      'version': '1.0' // Data structure version
     };
+  };
 
-    var load_ipython_extension = function () {
-        events.on('execute.CodeCell', function(ev, payload){
-            // Output area objects don't know what cells they belong to!
-            // We use this to tell them
-            // We keep re-setting it, but the other option was to monkeypatch
-            // CodeCell's fromJSON (for initial cell loading) and create_element
-            // calls. Unfortunately nbextensions run too late to usefully
-            // monkeypatch fromJSON, so this is what we gotta do.
-            payload.cell.output_area.cell = payload.cell;
-        });
-
-        // Add some metadata to the notebook itself
-        // This allows us to incrementally upgrade our format in the future
-        // in backwards compatible ways
-        jupyter.notebook.metadata.timetravel = {
-            'verson': '1.0' // Data structure version
-        };
-    };
-
-    return {
-        load_ipython_extension: load_ipython_extension
-    };
+  return {
+    load_ipython_extension: load_ipython_extension,
+  };
 });

--- a/nbtimetravel/static/main.js
+++ b/nbtimetravel/static/main.js
@@ -5,6 +5,10 @@ define([
 ], function (
   Jupyter, oa, events
 ) {
+  // Version of the extension. Allows us to upgrade the format in backwards
+  // compatible ways.
+  var timetravelVersion = '1.0';
+
   // No event for this, so we monkeypatch!
   // MONKEY SEE, MONKEY PATCH!
   oa.OutputArea.prototype._handle_output = oa.OutputArea.prototype.handle_output;
@@ -32,17 +36,36 @@ define([
   };
 
   var load_ipython_extension = function () {
-    events.on('execute.CodeCell', function(ev, payload){
-      // Output area objects don't know what cells they belong to!
-      // We use this to tell them
-      // We keep re-setting it, but the other option was to monkeypatch
-      // CodeCell's fromJSON (for initial cell loading) and create_element
-      // calls. Unfortunately nbextensions run too late to usefully
-      // monkeypatch fromJSON, so this is what we gotta do.
-      payload.cell.output_area.cell = payload.cell;
-    });
+    // This extension is only enabled for notebooks that have explicitly set a
+    //
+    // timetravel: { enabled: true }
+    //
+    // in the notebook metadata so that only notebooks that have been tested to
+    // not get too big will record history. This should eventually be replaced
+    // with a size limit on the history, but this will do for now.
+    //
+    // TODO: Replace with a size limit on history
+    var timetravelMeta = Jupyter.notebook.metadata.timetravel;
+    var isTimetravelEnabled = timetravelMeta && timetravelMeta.enabled;
 
-    // Add some metadata to the notebook itself
+    if (isTimetravelEnabled) {
+      // Modifies the metadata of the notebook itself:
+      // Sets version if it doesn't exist
+      if (!timetravelMeta.version) {
+        timetravelMeta.version = timetravelVersion;
+      }
+
+      events.on('execute.CodeCell', function(ev, payload){
+        // Output area objects don't know what cells they belong to!
+        // We use this to tell them
+        // We keep re-setting it, but the other option was to monkeypatch
+        // CodeCell's fromJSON (for initial cell loading) and create_element
+        // calls. Unfortunately nbextensions run too late to usefully
+        // monkeypatch fromJSON, so this is what we gotta do.
+        payload.cell.output_area.cell = payload.cell;
+      });
+    }
+
     // This allows us to incrementally upgrade our format in the future
     // in backwards compatible ways
     Jupyter.notebook.metadata.timetravel = {

--- a/nbtimetravel/static/main.js
+++ b/nbtimetravel/static/main.js
@@ -9,36 +9,38 @@ define([
   // compatible ways.
   var timetravelVersion = '1.0';
 
-  // No event for this, so we monkeypatch!
-  // MONKEY SEE, MONKEY PATCH!
-  oa.OutputArea.prototype._handle_output = oa.OutputArea.prototype.handle_output;
-  oa.OutputArea.prototype.handle_output = function (msg) {
-    if (!this.cell.metadata.history) {
-      this.cell.metadata.history = [];
-    }
-    this.cell.metadata.history.push({
-      // Record dates clientside, rather than serverside.
-      // This lets us consistently use the same time source in *most*
-      // cases.
-      timestamp: (new Date()).toISOString(),
-      code: this.cell.get_text(),
-      // We record the responses that're required to recreate the state
-      // in the OutputArea object.
-      response: {
-        version: msg.header.version,
-        msg_type: msg.msg_type,
-        content: msg.content,
-        metadata: msg.metadata
+  var setupHistoryRecorder = function () {
+    // No event for this, so we monkeypatch!
+    // MONKEY SEE, MONKEY PATCH!
+    oa.OutputArea.prototype._handle_output = oa.OutputArea.prototype.handle_output;
+    oa.OutputArea.prototype.handle_output = function (msg) {
+      if (!this.cell.metadata.history) {
+        this.cell.metadata.history = [];
       }
-    });
+      this.cell.metadata.history.push({
+        // Record dates clientside, rather than serverside.
+        // This lets us consistently use the same time source in *most*
+        // cases.
+        timestamp: (new Date()).toISOString(),
+        code: this.cell.get_text(),
+        // We record the responses that're required to recreate the state
+        // in the OutputArea object.
+        response: {
+          version: msg.header.version,
+          msg_type: msg.msg_type,
+          content: msg.content,
+          metadata: msg.metadata
+        }
+      });
 
-    return this._handle_output(msg);
-  };
+      return this._handle_output(msg);
+    };
+  }
 
   var load_ipython_extension = function () {
     // This extension is only enabled for notebooks that have explicitly set a
     //
-    // timetravel: { enabled: true }
+    // "timetravel": { "enabled": true }
     //
     // in the notebook metadata so that only notebooks that have been tested to
     // not get too big will record history. This should eventually be replaced
@@ -64,6 +66,8 @@ define([
         // monkeypatch fromJSON, so this is what we gotta do.
         payload.cell.output_area.cell = payload.cell;
       });
+
+      setupHistoryRecorder();
     }
 
     // This allows us to incrementally upgrade our format in the future

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,6 @@ setuptools.setup(
     data_files=[
         ('share/jupyter/nbextensions/nbhistory', glob('*.js'))
     ],
+    package_data={'nbtimetravel': ['static/*']},
     packages=setuptools.find_packages()
 )


### PR DESCRIPTION
# **Summary**
This commit adds a button on the menu toolbar of a Jupyter notebook. This button displays whether the nbtimetravel extension is on or off. To change this setting, simply click the button, and the button's display with change accordingly. By default, the extension is disabled. This tool lets students to decide whether to allow others to see their work. 

# **How to test**

1. Create a new notebook .
2. Run a cell a couple of times that has some output (currently, this extension doesn't record history if there is no output) and verify that the history is not saved (since, by default, the extension is disabled). 
3. Click the button once to enable the extension. Verify that the button shows that the extension is now 'On'.
4. Verify that the notebook does save history now. 
5. Click the button again to disable the extension. Verify that the button shows that the extension is now 'Off'.
6. Verify that the notebook does not save history now. 
 