### PR TITLE
Address milestone 0.1 tasks!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,115 @@
+### macOS ###
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+# Thumbnails
+._*
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+.venv/
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject

--- a/nbtimetravel/__init__.py
+++ b/nbtimetravel/__init__.py
@@ -1,7 +1,7 @@
 def _jupyter_nbextension_paths():
     return [{
         "section": "notebook",
-        "dest": "noteboard-nbextension",
+        "dest": "nbtimetravel",
         "src": "static",
-        "require": "noteboard-nbextension/main"
+        "require": "nbtimetravel/main"
     }]

--- a/nbtimetravel/static/main.js
+++ b/nbtimetravel/static/main.js
@@ -26,7 +26,7 @@ define([
     version: timetravelVersion,
 
     // Only these content types will be recorded in the history. Used to
-    // prevent huge notebooks from saving plots.
+    // prevent file size growth from recording plots.
     allowedContentTypes: [
       'text/plain',
     ],

--- a/nbtimetravel/static/main.js
+++ b/nbtimetravel/static/main.js
@@ -11,26 +11,7 @@ define([
   // Version of the extension. Allows us to upgrade the format in backwards
   // compatible ways.
   var timetravelVersion = '1.0';
-
-  // Initialize timetravel metadata if needed
-  Jupyter.notebook.metadata.timetravel = (
-    Jupyter.notebook.metadata.timetravel || {});
-
-  // Add some metadata to the notebook itself.
-  var timetravelMeta = Jupyter.notebook.metadata.timetravel;
-  _.defaults(timetravelMeta, {
-    // Disable the extension by default
-    enabled: false,
-
-    // Version the history format
-    version: timetravelVersion,
-
-    // Only these content types will be recorded in the history. Used to
-    // prevent file size growth from recording plots.
-    allowedContentTypes: [
-      'text/plain',
-    ],
-  });
+  var timetravelMeta;
 
   function indicatorToMsg() {
     if (timetravelMeta.enabled) {
@@ -97,6 +78,26 @@ define([
 
 
   var load_ipython_extension = function () {
+    // Initialize timetravel metadata if needed
+    Jupyter.notebook.metadata.timetravel = (
+      Jupyter.notebook.metadata.timetravel || {});
+
+    // Add some metadata to the notebook itself.
+    timetravelMeta = Jupyter.notebook.metadata.timetravel;
+    _.defaults(timetravelMeta, {
+      // Disable the extension by default
+      enabled: false,
+
+      // Version the history format
+      version: timetravelVersion,
+
+      // Only these content types will be recorded in the history. Used to
+      // prevent file size growth from recording plots.
+      allowedContentTypes: [
+        'text/plain',
+      ],
+    });
+
     // Initialize button toggle
     createButton();
     displayMsg();

--- a/nbtimetravel/static/main.js
+++ b/nbtimetravel/static/main.js
@@ -19,7 +19,7 @@ define([
   //
   // TODO: Replace with a size limit on history
   Jupyter.notebook.metadata.timetravel = (
-    Jupyter.notebook.metadata.timetravel || {})
+    Jupyter.notebook.metadata.timetravel || {});
   var timetravelMeta = Jupyter.notebook.metadata.timetravel;
   _.defaults(timetravelMeta, {
     enabled: false,
@@ -77,7 +77,7 @@ define([
           version: msg.header.version,
           msg_type: msg.msg_type,
           content: msg.content,
-          metadata: msg.metadata
+          metadata: msg.metadata,
         }
       });
     }
@@ -101,10 +101,9 @@ define([
     });
 
     $('#nbtimetravel-button').on('click', function() {
-      timetravelMeta.enabled = !timetravelMeta.enabled
+      timetravelMeta.enabled = !timetravelMeta.enabled;
       displayMsg();
-    })
-
+    });
   };
 
   return {

--- a/nbtimetravel/static/main.js
+++ b/nbtimetravel/static/main.js
@@ -1,56 +1,56 @@
 define([
-    'base/js/namespace',
-    'notebook/js/outputarea',
-    'base/js/events',
+  'base/js/namespace',
+  'notebook/js/outputarea',
+  'base/js/events',
 ], function (
-    Jupyter, oa, events
+  Jupyter, oa, events
 ) {
-    // No event for this, so we monkeypatch!
-    // MONKEY SEE, MONKEY PATCH!
-    oa.OutputArea.prototype._handle_output = oa.OutputArea.prototype.handle_output;
-    oa.OutputArea.prototype.handle_output = function (msg) {
-        if (!this.cell.metadata.history) {
-            this.cell.metadata.history = [];
-        }
-        this.cell.metadata.history.push({
-            // Record dates clientside, rather than serverside.
-            // This lets us consistently use the same time source in *most*
-            // cases.
-            timestamp: (new Date()).toISOString(),
-            code: this.cell.get_text(),
-            // We record the responses that're required to recreate the state
-            // in the OutputArea object.
-            response: {
-                version: msg.header.version,
-                msg_type: msg.msg_type,
-                content: msg.content,
-                metadata: msg.metadata
-            }
-        });
+  // No event for this, so we monkeypatch!
+  // MONKEY SEE, MONKEY PATCH!
+  oa.OutputArea.prototype._handle_output = oa.OutputArea.prototype.handle_output;
+  oa.OutputArea.prototype.handle_output = function (msg) {
+    if (!this.cell.metadata.history) {
+      this.cell.metadata.history = [];
+    }
+    this.cell.metadata.history.push({
+      // Record dates clientside, rather than serverside.
+      // This lets us consistently use the same time source in *most*
+      // cases.
+      timestamp: (new Date()).toISOString(),
+      code: this.cell.get_text(),
+      // We record the responses that're required to recreate the state
+      // in the OutputArea object.
+      response: {
+        version: msg.header.version,
+        msg_type: msg.msg_type,
+        content: msg.content,
+        metadata: msg.metadata
+      }
+    });
 
-        return this._handle_output(msg);
+    return this._handle_output(msg);
+  };
+
+  var load_ipython_extension = function () {
+    events.on('execute.CodeCell', function(ev, payload){
+      // Output area objects don't know what cells they belong to!
+      // We use this to tell them
+      // We keep re-setting it, but the other option was to monkeypatch
+      // CodeCell's fromJSON (for initial cell loading) and create_element
+      // calls. Unfortunately nbextensions run too late to usefully
+      // monkeypatch fromJSON, so this is what we gotta do.
+      payload.cell.output_area.cell = payload.cell;
+    });
+
+    // Add some metadata to the notebook itself
+    // This allows us to incrementally upgrade our format in the future
+    // in backwards compatible ways
+    Jupyter.notebook.metadata.timetravel = {
+      'version': '1.0' // Data structure version
     };
+  };
 
-    var load_ipython_extension = function () {
-        events.on('execute.CodeCell', function(ev, payload){
-            // Output area objects don't know what cells they belong to!
-            // We use this to tell them
-            // We keep re-setting it, but the other option was to monkeypatch
-            // CodeCell's fromJSON (for initial cell loading) and create_element
-            // calls. Unfortunately nbextensions run too late to usefully
-            // monkeypatch fromJSON, so this is what we gotta do.
-            payload.cell.output_area.cell = payload.cell;
-        });
-
-        // Add some metadata to the notebook itself
-        // This allows us to incrementally upgrade our format in the future
-        // in backwards compatible ways
-        jupyter.notebook.metadata.timetravel = {
-            'verson': '1.0' // Data structure version
-        };
-    };
-
-    return {
-        load_ipython_extension: load_ipython_extension
-    };
+  return {
+    load_ipython_extension: load_ipython_extension,
+  };
 });

--- a/nbtimetravel/static/main.js
+++ b/nbtimetravel/static/main.js
@@ -5,6 +5,10 @@ define([
 ], function (
   Jupyter, oa, events
 ) {
+  // Version of the extension. Allows us to upgrade the format in backwards
+  // compatible ways.
+  var timetravelVersion = '1.0';
+
   // No event for this, so we monkeypatch!
   // MONKEY SEE, MONKEY PATCH!
   oa.OutputArea.prototype._handle_output = oa.OutputArea.prototype.handle_output;
@@ -32,17 +36,36 @@ define([
   };
 
   var load_ipython_extension = function () {
-    events.on('execute.CodeCell', function(ev, payload){
-      // Output area objects don't know what cells they belong to!
-      // We use this to tell them
-      // We keep re-setting it, but the other option was to monkeypatch
-      // CodeCell's fromJSON (for initial cell loading) and create_element
-      // calls. Unfortunately nbextensions run too late to usefully
-      // monkeypatch fromJSON, so this is what we gotta do.
-      payload.cell.output_area.cell = payload.cell;
-    });
+    // This extension is only enabled for notebooks that have explicitly set a
+    //
+    // timetravel: { enabled: true }
+    //
+    // in the notebook metadata so that only notebooks that have been tested to
+    // not get too big will record history. This should eventually be replaced
+    // with a size limit on the history, but this will do for now.
+    //
+    // TODO: Replace with a size limit on history
+    var timetravelMeta = Jupyter.notebook.metadata.timetravel;
+    var isTimetravelEnabled = timetravelMeta && timetravelMeta.enabled;
 
-    // Add some metadata to the notebook itself
+    if (isTimetravelEnabled) {
+      // Modifies the metadata of the notebook itself:
+      // Sets version if it doesn't exist
+      if (!timetravelMeta.version) {
+        timetravelMeta.version = timetravelVersion;
+      }
+
+      events.on('execute.CodeCell', function(ev, payload){
+        // Output area objects don't know what cells they belong to!
+        // We use this to tell them
+        // We keep re-setting it, but the other option was to monkeypatch
+        // CodeCell's fromJSON (for initial cell loading) and create_element
+        // calls. Unfortunately nbextensions run too late to usefully
+        // monkeypatch fromJSON, so this is what we gotta do.
+        payload.cell.output_area.cell = payload.cell;
+      });
+    }
+
     // This allows us to incrementally upgrade our format in the future
     // in backwards compatible ways
     Jupyter.notebook.metadata.timetravel = {

--- a/nbtimetravel/static/main.js
+++ b/nbtimetravel/static/main.js
@@ -9,36 +9,38 @@ define([
   // compatible ways.
   var timetravelVersion = '1.0';
 
-  // No event for this, so we monkeypatch!
-  // MONKEY SEE, MONKEY PATCH!
-  oa.OutputArea.prototype._handle_output = oa.OutputArea.prototype.handle_output;
-  oa.OutputArea.prototype.handle_output = function (msg) {
-    if (!this.cell.metadata.history) {
-      this.cell.metadata.history = [];
-    }
-    this.cell.metadata.history.push({
-      // Record dates clientside, rather than serverside.
-      // This lets us consistently use the same time source in *most*
-      // cases.
-      timestamp: (new Date()).toISOString(),
-      code: this.cell.get_text(),
-      // We record the responses that're required to recreate the state
-      // in the OutputArea object.
-      response: {
-        version: msg.header.version,
-        msg_type: msg.msg_type,
-        content: msg.content,
-        metadata: msg.metadata
+  var setupHistoryRecorder = function () {
+    // No event for this, so we monkeypatch!
+    // MONKEY SEE, MONKEY PATCH!
+    oa.OutputArea.prototype._handle_output = oa.OutputArea.prototype.handle_output;
+    oa.OutputArea.prototype.handle_output = function (msg) {
+      if (!this.cell.metadata.history) {
+        this.cell.metadata.history = [];
       }
-    });
+      this.cell.metadata.history.push({
+        // Record dates clientside, rather than serverside.
+        // This lets us consistently use the same time source in *most*
+        // cases.
+        timestamp: (new Date()).toISOString(),
+        code: this.cell.get_text(),
+        // We record the responses that're required to recreate the state
+        // in the OutputArea object.
+        response: {
+          version: msg.header.version,
+          msg_type: msg.msg_type,
+          content: msg.content,
+          metadata: msg.metadata
+        }
+      });
 
-    return this._handle_output(msg);
-  };
+      return this._handle_output(msg);
+    };
+  }
 
   var load_ipython_extension = function () {
     // This extension is only enabled for notebooks that have explicitly set a
     //
-    // timetravel: { enabled: true }
+    // "timetravel": { "enabled": true }
     //
     // in the notebook metadata so that only notebooks that have been tested to
     // not get too big will record history. This should eventually be replaced
@@ -64,6 +66,8 @@ define([
         // monkeypatch fromJSON, so this is what we gotta do.
         payload.cell.output_area.cell = payload.cell;
       });
+
+      setupHistoryRecorder();
     }
 
     // This allows us to incrementally upgrade our format in the future

--- a/nbtimetravel/static/main.js
+++ b/nbtimetravel/static/main.js
@@ -53,7 +53,7 @@ define([
 
       // Only record whitelisted content types
       var recordedContent = _.clone(msg.content);
-      recordedContent.data = _.pick(msg.content.data,
+      recordedContent.data = _.pick(msg.content.data || {},
                                     timetravelMeta.allowedContentTypes);
 
       this.cell.metadata.history.push({

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,6 @@ setuptools.setup(
     data_files=[
         ('share/jupyter/nbextensions/nbhistory', glob('*.js'))
     ],
+    package_data={'nbtimetravel': ['static/*']},
     packages=setuptools.find_packages()
 )


### PR DESCRIPTION
Summary
-----

My friend @dfannjiang and I made a first pass at your issues for milestone 0.1!

To address the issues of file size (#6), we decided to only record down the
history for text output. See https://github.com/data-8/nbtimetravel/pull/3 for
how that was implemented. We essentially only record content types that are
explicitly whitelisted. Currently, the whitelist defaults to `text/plain`.

We've added an indicator in the upper right corner that shows when the
extension is active. Clicking the button toggles the indicator on and off. See
https://github.com/data-8/nbtimetravel/pull/2 for the original PR.

Do note that toggling the extension off does not clear the original history. We
figured that with clear instructions, students would be able to toggle it off
themselves and students that really want everything cleared can just email us.
It was also easier to implement.

Toggling the extension on/off is persisted between refreshes since we save it
in the notebook metadata.

Here a screenshot of the notebook, see the button in the upper right.

![screenshot 2016-11-28 01 17 21](https://cloud.githubusercontent.com/assets/2468904/20662483/6def34a0-b508-11e6-8c23-1298aeff2a7c.png)

How to test
-----

Creating a new notebook

1. After installing extension, create a new notebook.
2. The indicator should show that timetravel is disabled. Running cells should
   not record history.

Enabling extension

1. After clicking the indicator to enable recording, run a cell a few times.
   Verify that the cell history is recorded. Verify that graphs and output HTML
   (eg. a pandas table) are not recorded.


Disabling extension

1. Disable the extension by clicking the indicator. Verify that the cell
   history is still present.
2. Run cells. Verify that output is not recorded.